### PR TITLE
Update documentation graphql_auth.schema --> graphql_auth.queries

### DIFF
--- a/README.md
+++ b/README.md
@@ -53,7 +53,7 @@ Documentation is available at [read the docs](https://django-graphene-auth.readt
 
 import graphene
 
-from graphql_auth.schema import UserQuery, MeQuery
+from graphql_auth.queries import UserQuery, MeQuery
 from graphql_auth import mutations
 
 class AuthMutation(graphene.ObjectType):

--- a/docs/api.md
+++ b/docs/api.md
@@ -11,7 +11,7 @@ GraphQL Auth also provides the MeQuery to retrieve data for the currently authen
 ### UserQuery
 
 ```python
-from graphql_auth.schema import UserQuery
+from graphql_auth.queries import UserQuery
 ```
 
 The easiest way to explore it is by using [graphQL](https://docs.graphene-python.org/projects/django/en/latest/tutorial-plain/#creating-graphql-and-graphiql-views).
@@ -150,7 +150,7 @@ Examples:
 ### MeQuery
 
 ```python
-from graphql_auth.schema import MeQuery
+from graphql_auth.queries import MeQuery
 ```
 
 Since this query requires an authenticated user it can be explored by using the [insomnia API client](https://insomnia.rest/).

--- a/docs/installation.md
+++ b/docs/installation.md
@@ -50,7 +50,7 @@ In your schema, add the following:
 
     import graphene
 
-    from graphql_auth.schema import UserQuery, MeQuery
+    from graphql_auth.queries import UserQuery, MeQuery
     from graphql_auth import mutations
 
     class AuthMutation(graphene.ObjectType):
@@ -92,7 +92,7 @@ In your schema, add the following:
 
     import graphene
 
-    from graphql_auth.schema import UserQuery, MeQuery
+    from graphql_auth.queries import UserQuery, MeQuery
     from graphql_auth import relay
 
     class AuthRelayMutation(graphene.ObjectType):


### PR DESCRIPTION
As mentioned in #1 the documentation must be updated, since `graphqul_auth.schema` was replaced by `graphql_auth.queries`.